### PR TITLE
mistake seeing env name

### DIFF
--- a/content/70_multi_env/00_add_env/_index.en.md
+++ b/content/70_multi_env/00_add_env/_index.en.md
@@ -39,7 +39,7 @@ For `? Enter a name for the environment`, please enter `staging`. After that, yo
 
 After a while, you see `Initialized your environment successfully.`, and then the process is done.
 
-Please run `amplify env list` again. There is a `production` environment on the list. The one with "\*" is the current environment where you are now.
+Please run `amplify env list` again. There is a `staging` environment on the list. The one with "\*" is the current environment where you are now.
 
 ```null
 $ amplify env list

--- a/content/70_multi_env/00_add_env/_index.ja.md
+++ b/content/70_multi_env/00_add_env/_index.ja.md
@@ -38,7 +38,7 @@ amplify env add
 
 しばらくして`Initialized your environment successfully.`と表示されれば処理は完了です。
 
-もう一度、`amplify env list`を実行してみましょう。「production」環境が追加されていることが確認できます。「\*」がついているのが現在の環境です。
+もう一度、`amplify env list`を実行してみましょう。「staging」環境が追加されていることが確認できます。「\*」がついているのが現在の環境です。
 
 ```null
 $ amplify env list


### PR DESCRIPTION
`amplify env list` can show `production` and `staging` after `amplify env add` and add staging environment