### PR TITLE
mistake environment name design

### DIFF
--- a/content/70_multi_env/20_branch_autodetection/_index.en.md
+++ b/content/70_multi_env/20_branch_autodetection/_index.en.md
@@ -104,7 +104,7 @@ When you are asked `? Do you want to use an existing environment?`, then enter `
 
 For `? Enter a name for the environment`, enter `design`. After that, you can answer with default options for all questions.
 
-Confirm that the staging environment has been created by running `amplify env list` command.
+Confirm that the design environment has been created by running `amplify env list` command.
 
 ```sh
 amplify env list

--- a/content/70_multi_env/20_branch_autodetection/_index.ja.md
+++ b/content/70_multi_env/20_branch_autodetection/_index.ja.md
@@ -98,7 +98,7 @@ amplify env add
 
 `? Do you want to use an existing environment?`と訊かれたら`No`を入力し Enter を押してください。`? Enter a name for the environment`には`design`を入力します。以降は、デフォルトの選択肢で Enter を押下します。
 
-`amplify env list`で staging 環境の設定が作成されていることを確認します。
+`amplify env list`で design 環境の設定が作成されていることを確認します。
 
 ```sh
 amplify env list


### PR DESCRIPTION
Write "Confirm that the staging environment has been created by running `amplify env list` command." but created is `design`